### PR TITLE
add modis_sinusoidal as a horizCoordSysName option

### DIFF
--- a/eml-spatialReferenceDictionary.xml
+++ b/eml-spatialReferenceDictionary.xml
@@ -33746,5 +33746,21 @@
       </projection>
     </projCoordSys>
   </horizCoordSysDef>
+  <horizCoordSysDef name="Sinusoidal">
+    <projCoordSys>
+      <geogCoordSys name="GCS_Undefined">
+        <datum name="Undefined"/>
+        <spheroid name="User_Defined_Spheroid" semiAxisMajor="6371007.181"/>
+        <primeMeridian name="Greenwich" longitude="0"/>
+        <unit name="degree" value="0.0174532925199433"/>
+      </geogCoordSys>
+      <projection name="Sinusoidal">
+        <parameter name="False_Easting" value="0.0"/>
+        <parameter name="False_Northing" value="0.0"/>
+        <parameter name="Central_Meridian" value="0.0"/>
+        <unit name="meter" value="1.0"/>
+      </projection>
+    </projCoordSys>
+  </horizCoordSysDef>
 </sp:projectionList>
 

--- a/xsd/eml-spatialReference.xsd
+++ b/xsd/eml-spatialReference.xsd
@@ -2139,7 +2139,7 @@
                 <xs:enumeration value="World_Winkel_I"/>
                 <xs:enumeration value="World_Winkel_II"/>
                 <xs:enumeration value="World_Winkel_Tripel_NGS"/>
-                <xs:enumeration value="modis_sinusoidal"/>
+                <xs:enumeration value="Sinusoidal"/>
               </xs:restriction>
             </xs:simpleType>
           </xs:element>

--- a/xsd/eml-spatialReference.xsd
+++ b/xsd/eml-spatialReference.xsd
@@ -2139,6 +2139,7 @@
                 <xs:enumeration value="World_Winkel_I"/>
                 <xs:enumeration value="World_Winkel_II"/>
                 <xs:enumeration value="World_Winkel_Tripel_NGS"/>
+                <xs:enumeration value="modis_sinusoidal"/>
               </xs:restriction>
             </xs:simpleType>
           </xs:element>


### PR DESCRIPTION
Requesting the addition of `modis_sinusoidal` as a `horizCoordSysName` option. Please see #352 for details. I am just taking a stab at naming this particular projection so am open to suggestions.