### PR TITLE
the funder registry moved over to gitlab

### DIFF
--- a/xsd/eml-project.xsd
+++ b/xsd/eml-project.xsd
@@ -475,7 +475,7 @@
             canonical identifiers that reference the funder.  These identifiers
             should be globally unique.  The most common form of a funder identifier
             is a DOI identifier of an institution or program drawn from the CrossRef
-            Open Funder Registry (https://github.com/Crossref/open-funder-registry),
+            Open Funder Registry (https://gitlab.com/crossref/open_funder_registry),
             which assigns DOIs to each funding agency and to their programs, and
             links these together in a navigable hierarchy.  A copy of the current
             Funder Registry is included as an RDF file with EML for reference, but


### PR DESCRIPTION
Just a very small documentation fix adjusting the url to the funder registry